### PR TITLE
Add AI-TCP session module

### DIFF
--- a/src/ai_tcp/README.md
+++ b/src/ai_tcp/README.md
@@ -1,2 +1,3 @@
 # AI-TCP Implementation Notes
 
+This directory contains prototype modules for the AI-TCP protocol.

--- a/src/ai_tcp/ai_tcp_session.go
+++ b/src/ai_tcp/ai_tcp_session.go
@@ -1,0 +1,45 @@
+package ai_tcp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log"
+	"time"
+)
+
+// AITCPSession represents a mock AI-TCP session between two models.
+type AITCPSession struct {
+	ID        string
+	ModelFrom string
+	ModelTo   string
+	StartTime time.Time
+}
+
+// InitAITCPSession initializes a new AITCPSession with the provided model names.
+func InitAITCPSession(modelFrom, modelTo string) *AITCPSession {
+	// Generate a 128-bit (16-byte) random session ID.
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		log.Fatalf("failed to generate session ID: %v", err)
+	}
+
+	return &AITCPSession{
+		ID:        hex.EncodeToString(buf),
+		ModelFrom: modelFrom,
+		ModelTo:   modelTo,
+		StartTime: time.Now(),
+	}
+}
+
+// SimulateConnection prints a mock handshake between the two models.
+func SimulateConnection(session *AITCPSession) {
+	if session == nil {
+		log.Println("no session provided")
+		return
+	}
+
+	log.Printf("[AI-TCP] Session %s initialized at %s", session.ID, session.StartTime.Format(time.RFC3339))
+	log.Printf("[AI-TCP] %s -> %s: initiating secure handshake", session.ModelFrom, session.ModelTo)
+	log.Printf("[AI-TCP] %s -> %s: handshake acknowledged", session.ModelTo, session.ModelFrom)
+	log.Printf("[AI-TCP] Session %s secure channel established", session.ID)
+}


### PR DESCRIPTION
## Summary
- add ai_tcp_session.go with session struct and mock connection handling
- update README for AI-TCP directory

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_684e67feae5c8333b7a23dce4ee61537